### PR TITLE
2: plugin only works with string field type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,17 +6,17 @@ const TYPESENSE_ATTRIBUTE_NAME = "data-typesense-field"
 let utils = require("./lib/utils")
 
 function typesenseGetValue(fieldDefinition, attributeValue) {
-  if (fieldDefinition.type.includes('int')) {
+  if (fieldDefinition.type.includes("int")) {
     return parseInt(attributeValue);
   }
-  if (fieldDefinition.type.includes('float')) {
+  if (fieldDefinition.type.includes("float")) {
     return parseFloat(attributeValue);
   }
-  if (fieldDefinition.type.includes('bool')) {
-    if (attributeValue.toLowerCase() === 'false') {
+  if (fieldDefinition.type.includes("bool")) {
+    if (attributeValue.toLowerCase() === "false") {
       return false;
     }
-    if (attributeValue === '0') {
+    if (attributeValue === "0") {
       return false;
     }
     return attributeValue.trim() !== "";

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const TYPESENSE_ATTRIBUTE_NAME = "data-typesense-field"
 
 let utils = require("./lib/utils")
 
-function typesenseGetValue(fieldDefinition, attributeValue) {
+function typeCastValue(fieldDefinition, attributeValue) {
   if (fieldDefinition.type.includes("int")) {
     return parseInt(attributeValue);
   }
@@ -49,9 +49,9 @@ async function indexContentInTypesense({
 
     if (fieldDefinition.type.includes("[]")) {
       typesenseDocument[attributeName] = typesenseDocument[attributeName] || []
-      typesenseDocument[attributeName].push(typesenseGetValue(fieldDefinition, attributeValue))
+      typesenseDocument[attributeName].push(typeCastValue(fieldDefinition, attributeValue))
     } else {
-      typesenseDocument[attributeName] = typesenseGetValue(fieldDefinition, attributeValue);
+      typesenseDocument[attributeName] = typeCastValue(fieldDefinition, attributeValue);
     }
   })
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,6 +5,25 @@ const TYPESENSE_ATTRIBUTE_NAME = "data-typesense-field"
 
 let utils = require("./lib/utils")
 
+function typesenseGetValue(fieldDefinition, attributeValue) {
+  if (fieldDefinition.type.includes('int')) {
+    return parseInt(attributeValue);
+  }
+  if (fieldDefinition.type.includes('float')) {
+    return parseFloat(attributeValue);
+  }
+  if (fieldDefinition.type.includes('bool')) {
+    if (attributeValue.toLowerCase() === 'false') {
+      return false;
+    }
+    if (attributeValue === '0') {
+      return false;
+    }
+    return attributeValue.trim() !== "";
+  }
+  return attributeValue;
+}
+
 async function indexContentInTypesense({
   fileContents,
   wwwPath,
@@ -30,9 +49,9 @@ async function indexContentInTypesense({
 
     if (fieldDefinition.type.includes("[]")) {
       typesenseDocument[attributeName] = typesenseDocument[attributeName] || []
-      typesenseDocument[attributeName].push(attributeValue)
+      typesenseDocument[attributeName].push(typesenseGetValue(fieldDefinition, attributeValue))
     } else {
-      typesenseDocument[attributeName] = attributeValue
+      typesenseDocument[attributeName] = typesenseGetValue(fieldDefinition, attributeValue);
     }
   })
 

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -63,6 +63,7 @@ describe("gatsby-node.js", () => {
         protocol: "http",
       },
     ],
+    logLevel: "debug", // Useful to know the last request that was made, especially when a mock is missing
   }
 
   const NEW_COLLECTION_NAME = `pages_v1_${Date.now()}`
@@ -88,7 +89,7 @@ describe("gatsby-node.js", () => {
 
   test("onPostBuild", async () => {
     mockAxios
-      .onGet("http://localhost:8108/collections", undefined, {
+      .onPost("http://localhost:8108/collections", undefined, {
         Accept: "application/json, text/plain, */*",
         "Content-Type": "application/json",
         "X-TYPESENSE-API-KEY": SERVER_CONFIG.apiKey,
@@ -126,6 +127,7 @@ describe("gatsby-node.js", () => {
           title: "About",
           description: "This is some about us content",
           stock: 4,
+          price: 9.99,
           published: true,
           tags: ["about", "misc"],
           score: [3, 5],

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -17,6 +17,26 @@ describe("gatsby-node.js", () => {
         type: "string",
       },
       {
+        name: "stock",
+        type: "int32",
+        optional: true,
+      },
+      {
+        name: "published",
+        type: "bool",
+        optional: true,
+      },
+      {
+        name: "score",
+        type: "int32[]",
+        optional: true,
+      },
+      {
+        name: "price",
+        type: "float",
+        optional: true,
+      },
+      {
         name: "tags",
         type: "string[]",
         optional: true,
@@ -105,7 +125,10 @@ describe("gatsby-node.js", () => {
         {
           title: "About",
           description: "This is some about us content",
+          stock: 4,
+          published: true,
           tags: ["about", "misc"],
+          score: [3, 5],
           page_path: "/about/",
           page_priority_score: 10,
         },

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -88,7 +88,7 @@ describe("gatsby-node.js", () => {
 
   test("onPostBuild", async () => {
     mockAxios
-      .onPost("http://localhost:8108/collections", undefined, {
+      .onGet("http://localhost:8108/collections", undefined, {
         Accept: "application/json, text/plain, */*",
         "Content-Type": "application/json",
         "X-TYPESENSE-API-KEY": SERVER_CONFIG.apiKey,

--- a/test/support/testground/gatsby-config-with-plugin.js
+++ b/test/support/testground/gatsby-config-with-plugin.js
@@ -23,6 +23,22 @@ module.exports = {
               type: "string",
             },
             {
+              name: "stock",
+              type: "int32",
+            },
+            {
+              name: "available",
+              type: "bool"
+            },
+            {
+              name: "score",
+              type: "int32[]",
+            },
+            {
+              name: "price",
+              type: "float",
+            },
+            {
               name: "tags",
               type: "string[]",
               optional: true,

--- a/test/support/testground/gatsby-config-with-plugin.js
+++ b/test/support/testground/gatsby-config-with-plugin.js
@@ -25,18 +25,22 @@ module.exports = {
             {
               name: "stock",
               type: "int32",
+              optional: true,
             },
             {
-              name: "available",
-              type: "bool"
+              name: "published",
+              type: "bool",
+              optional: true,
             },
             {
               name: "score",
               type: "int32[]",
+              optional: true,
             },
             {
               name: "price",
               type: "float",
+              optional: true,
             },
             {
               name: "tags",

--- a/test/support/testground/src/pages/about.js
+++ b/test/support/testground/src/pages/about.js
@@ -15,7 +15,7 @@ export default function About() {
       {/* An example of an int32 field */}
       <div data-typesense-field={"stock"}>4</div>
       {/* An example of a bool field */}
-      <div data-typesense-field={"available"}>true</div>
+      <div data-typesense-field={"published"}>true</div>
       <div>
         {/* An example of an string[] field */}
         <span data-typesense-field={"tags"}>about</span>

--- a/test/support/testground/src/pages/about.js
+++ b/test/support/testground/src/pages/about.js
@@ -6,12 +6,25 @@ export default function About() {
   return (
     <div>
       <Header pageName="About" />
+      {/* An example of a string field */}
       <div data-typesense-field={"description"}>
         This is some about us content
       </div>
+      {/* An example of a float field */}
+      <div data-typesense-field={"price"}>9.99</div>
+      {/* An example of an int32 field */}
+      <div data-typesense-field={"stock"}>4</div>
+      {/* An example of a bool field */}
+      <div data-typesense-field={"available"}>true</div>
       <div>
+        {/* An example of an string[] field */}
         <span data-typesense-field={"tags"}>about</span>
         <span data-typesense-field={"tags"}>misc</span>
+      </div>
+      <div>
+        {/* An example of an int32[] field */}
+        <span data-typesense-field={"score"}>3</span>
+        <span data-typesense-field={"score"}>5</span>
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
## Change Summary
Pertains to issue: https://github.com/typesense/gatsby-plugin-typesense/issues/2

Adds a new function to **gatsby-node.js** called **typesenseGetValue**, which checks the field type and converts the value to the correct type:

-  if a field is an int32/int64 the field value will be converted via the parseInt() function
-  if a field is of type float the value will be converted via the parseFloat() function
-  if a field is of type boolean, the value will be checked to see if it is either "0", an empty string or "false" returning false, otherwise true.

This works with a list of values and with singular values i.e. float & float[]

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).